### PR TITLE
extract_translation Script: Add support for finding strings of IDs that require pronoun identifiers

### DIFF
--- a/cbpickaxe_scripts/extract_translation.py
+++ b/cbpickaxe_scripts/extract_translation.py
@@ -66,11 +66,16 @@ def main(argv: List[str]) -> int:
             find_string(i)
 
             if len(row.keys()) == 1:
-                i += ".n"
-                row["id"] = i
-                find_string(i)
-            
-            writer.writerow(row)
+                pronouns = [".f", ".m", ".n"]
+                ids_with_pronouns = []
+                for pronoun in pronouns:
+                    ids_with_pronouns.append(i + pronoun)
+                for id_with_pronoun in ids_with_pronouns:
+                    row["id"] = id_with_pronoun
+                    find_string(id_with_pronoun)
+                    writer.writerow(row)
+            else:
+                writer.writerow(row)
                         
             """
             NOTES REGARDING THE ORIGINAL CODE:

--- a/cbpickaxe_scripts/extract_translation.py
+++ b/cbpickaxe_scripts/extract_translation.py
@@ -48,23 +48,41 @@ def main(argv: List[str]) -> int:
             ouput_stream, fieldnames=["id", *sorted(set(locales.values()))]
         )
         writer.writeheader()
-
-        for i in strings_to_translate:
-            row = {
-                "id": i,
-            }
+        
+        def find_string(id):
             for name, table in tables.items():
                 locale = locales[name]
-                message = table.get(i, "")
+                message = table.get(id, "")
                 assert isinstance(message, str)
 
                 if message != "":
                     row[locale] = message
 
+        for i in strings_to_translate:
+            row = {
+                "id": i,
+            }
+            
+            find_string(i)
+
+            if len(row.keys()) == 1:
+                i += ".n"
+                row["id"] = i
+                find_string(i)
+            
             writer.writerow(row)
+                        
+            """
+            NOTES REGARDING THE ORIGINAL CODE:
+            - IDs with no string found did not have the locale key
+                Possible solutions:
+                - Check if the string ID does not have the locale key
+                    - if locale not in row.keys():
+                - Check if the string ID only has one key (id)
+                    - if len(row.keys()) == 1:
+            """
 
     return SUCCESS
-
 
 def main_without_args() -> int:
     return main(sys.argv[1:])

--- a/cbpickaxe_scripts/extract_translation.py
+++ b/cbpickaxe_scripts/extract_translation.py
@@ -68,8 +68,10 @@ def main(argv: List[str]) -> int:
             if len(row.keys()) == 1:
                 pronouns = [".f", ".m", ".n"]
                 ids_with_pronouns = []
+                
                 for pronoun in pronouns:
                     ids_with_pronouns.append(i + pronoun)
+                    
                 for id_with_pronoun in ids_with_pronouns:
                     row["id"] = id_with_pronoun
                     find_string(id_with_pronoun)
@@ -78,6 +80,7 @@ def main(argv: List[str]) -> int:
                 writer.writerow(row)
 
     return SUCCESS
+
 
 def main_without_args() -> int:
     return main(sys.argv[1:])

--- a/cbpickaxe_scripts/extract_translation.py
+++ b/cbpickaxe_scripts/extract_translation.py
@@ -76,16 +76,6 @@ def main(argv: List[str]) -> int:
                     writer.writerow(row)
             else:
                 writer.writerow(row)
-                        
-            """
-            NOTES REGARDING THE ORIGINAL CODE:
-            - IDs with no string found did not have the locale key
-                Possible solutions:
-                - Check if the string ID does not have the locale key
-                    - if locale not in row.keys():
-                - Check if the string ID only has one key (id)
-                    - if len(row.keys()) == 1:
-            """
 
     return SUCCESS
 


### PR DESCRIPTION
The current version of the `extract_translation` script is unable to extract strings that require gender/pronoun identifiers. Specifically, these strings are listed in `analysis.tres` from the `translation` folder of the decompiled Cassette Beasts game under the `pronouns` list.

My solution is to append gender identifiers, specifically `.f`, `.m` and `.n`, to the end of string IDs that need them, then look for the strings for the IDs with gender identifiers, and lastly write each string ID with gender identifier as a separate row in the output CSV file. For example, for the string ID `AA_CUBE_POST_BATTLE_MEREDITH3`, the output in the CSV will be:
```
id,en

AA_CUBE_POST_BATTLE_MEREDITH3.f,"I guess that was another addition to my list of “weird things on this island that tried to kill me”. [pause]Great stuff, mate."

AA_CUBE_POST_BATTLE_MEREDITH3.m,"I guess that was another addition to my list of “weird things on this island that tried to kill me”. [pause]Great stuff, mate."

AA_CUBE_POST_BATTLE_MEREDITH3.n,"I guess that was another addition to my list of “weird things on this island that tried to kill me”. [pause]Great stuff, mate."
```
However, users can still manually add a gender identifier to the string ID in the text file input to extract the string for that specific gender identifier.